### PR TITLE
Export parseConfigJson

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export async function resolveSchema (config: Config): Promise<Schema> {
   }
 }
 
-function parseConfigJson (json: any): Config {
+export function parseConfigJson (json: any): Config {
   if (json.file) {
     return {
       file: json.file,


### PR DESCRIPTION
This allows specifying GraphQL config other places where it is more convenient such as `.eslintrc` rather than force user to have to reconfigure graphQL endpoint elsewhere such as .graphqlrc or package.json