### PR TITLE
Leave absolute paths intact.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^2.1.0-dev.20160805"
   },
   "dependencies": {
-    "graphql": "^0.7.1",
+    "graphql": "0.7.1 - 1.0.0",
     "node-fetch": "^1.6.3",
     "valid-url": "^1.0.9"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { isWebUri } from 'valid-url'
 import { readFileSync } from 'fs'
-import { join } from 'path'
+import { resolve } from 'path'
 import { graphql } from 'graphql/graphql'
 import { introspectionQuery } from 'graphql/utilities/introspectionQuery'
 import * as fetch from 'node-fetch'
@@ -62,7 +62,7 @@ export function parse (path: string = process.cwd()): Config {
 export async function resolveSchema (config: Config): Promise<Schema> {
   switch (config.type) {
     case 'file':
-      const schema = require(join(process.cwd(), config.file))
+      const schema = require(resolve(config.file))
       console.log(`Loaded GraphQL schema from ${config.file}`)
       return Promise.resolve(schema)
     case 'request':
@@ -94,7 +94,7 @@ export async function resolveSchema (config: Config): Promise<Schema> {
           }
         })
      case 'graphql-js':
-       const schemaSource = require(join(process.cwd(), config.file))
+       const schemaSource = require(resolve(config.file))
        console.log(`Loaded GraphQL schema from ${config.file}`)
        return graphql(schemaSource.default || schemaSource, introspectionQuery)
 


### PR DESCRIPTION
This PR makes it so that only relative paths to schema files get expanded against the cwd, absolute paths are left alone.

In addition I’ve loosened the version constraint on the graphic package so that e.g. 0.8.2 can be installed and shared. I did cap it to 1.0.0 just in case, but don’t feel strong about that.