### PR TITLE
add support for headers with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The easiest way to configure your project is by setting an environment variable 
 export GRAPHQL_ENDPOINT="https://your.api/graphql"
 ```
 
+You can also configure headers with the `GRAPHQL_HEADERS` environment variable. The value must be a valid JSON string.
+
+```sh
+export GRAPHQL_HEADERS="{\"Authorization\":\"xxxxx\"}"
+```
+
 ### Method 2: Configuration via `.graphqlrc` file
 
 You can either use your actual GraphQL endpoint or if preferred a local schema.json or schema.js file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-config-parser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The easiest way to configure your development environment with your GraphQL schema (supported by most tools, editors & IDEs)",
   "main": "src/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,9 +50,18 @@ export function parse (path: string = process.cwd()): Config {
       throw new Error(`No valid GraphQL endpoint: ${endpoint}`)
     }
 
+    let headers
+    if (process.env.hasOwnProperty('GRAPHQL_HEADERS')) {
+      try {
+        headers = JSON.parse(process.env.GRAPHQL_HEADERS)
+      } catch (ex) {
+        throw new Error(`GraphQL headers are not valid JSON`)
+      }
+    }
     return {
       url: endpoint,
       type: 'request',
+      headers,
     } as ConfigRequest
   }
 

--- a/tests/env/test.ts
+++ b/tests/env/test.ts
@@ -9,6 +9,7 @@ test.before(async t => {
 
 test(async (t) => {
   process.env['GRAPHQL_ENDPOINT'] = 'http://localhost:33333'
+  process.env['GRAPHQL_HEADERS'] = '{"authorization":"xxxxx"}'
 
   const config = parse()
   const resolvedSchema = await resolveSchema(config)


### PR DESCRIPTION
It seemed odd to not support headers via environment variables, so I'm hoping you find this PR useful.

I need this functionality and would prefer not to have to rewrite the whole `babel-plugin-react-relay` plugin just for my use case.

Thanks!