### PR TITLE
fix the glob matching by relaxing the lstat check

### DIFF
--- a/src/GraphQLProjectConfig.ts
+++ b/src/GraphQLProjectConfig.ts
@@ -62,8 +62,8 @@ export class GraphQLProjectConfig {
     return (
       (
         !this.config.includes ||
-        matchesGlobs(filePath, this.configDir, this.includes)
-      ) && !matchesGlobs(filePath, this.configDir, this.excludes)
+        matchesGlobs(relativePath, this.configDir, this.includes)
+      ) && !matchesGlobs(relativePath, this.configDir, this.excludes)
     )
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,9 +57,9 @@ export function matchesGlobs(filePath: string, configDir: string, globs?: string
       return minimatch(filePath, globToMatch, {matchBase: true})
     } catch (error) {
       // Out of errors that lstat provides, EACCES and ENOENT are the
-      // most likely. For both cases there is no need to continue
-      // furthermore with the glob match.
-      return false
+      // most likely. For both cases, run the match with the raw glob
+      // and return the result.
+      return minimatch(filePath, glob, {matchBase: true})
     }
   })
 }


### PR DESCRIPTION
- fix the incorrect merge resolution
- run `minimatch` in case the `lstat` fails due to already included glob pattern