### PR TITLE
handle the case with empty glob pattern

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,7 @@ export function matchesGlobs(filePath: string, configDir: string, globs?: string
   return (globs || []).some(glob => {
     try {
       const globStat = lstatSync(join(configDir, glob))
+      const newGlob = glob.length === 0 ? '.' : glob;
       const globToMatch = globStat.isDirectory() ? `${glob}/**` : glob
       return minimatch(filePath, globToMatch, {matchBase: true})
     } catch (error) {


### PR DESCRIPTION
For instance:
```
{
  "includes": [ "", "../shared" ]
}
```
The above indicates we're including the root directory and the shared directory not within the subdirectories - the glob match fails without this.