### PR TITLE
set an explicit version for `graphql` to fix flow issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^2.1.0-dev.20160805"
   },
   "dependencies": {
-    "graphql": "0.7.1 - 1.0.0",
+    "graphql": "^0.11.5",
     "graphql-request": "^1.2.0",
     "js-yaml": "^3.9.0",
     "minimatch": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,11 +1547,11 @@ graphql-request@^1.2.0:
   dependencies:
     isomorphic-fetch "^2.2.1"
 
-"graphql@0.7.1 - 1.0.0":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.4.tgz#55ae6857ae521e3592aec4265587e5e94c477667"
+graphql@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.5.tgz#9744b3578ab760687e4a861b4e07ff9f1c5286d1"
   dependencies:
-    iterall "^1.1.0"
+    iterall "1.1.2"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -1822,9 +1822,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+iterall@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.2.tgz#413332b3cdb46f8f5ede57d6cd8e3ca8a9df8816"
 
 js-tokens@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
With Flow version v0.55.0, a list of flow errors about object `null` prototype has been exposed to `graphql@0.11.4`. I've resolved them and released `graphql@0.11.5`, but this library loosely defines the version number, which makes other libraries (like `graphql-language-service`) prone to errors unless an explicit update is done.

I'm not sure why we're doing it this way - frankly I think we could define an explicit version number and either use something like `greenkeeper` to keep track of the releases, or manually update them as we see fit. However the case may be, I'm making this change to unblock other software depending on `graphql` from flow issues. I'll release a new version of `graphql-config` right away with this included.

Sorry if this was an uncomfortable change - I'm willing to work together/discuss what the best course of action there may be if anyone objects with this change.