### PR TITLE
fix and expose getUsedEnvs

### DIFF
--- a/src/__tests__/endpoint-extension/string-refs.ts
+++ b/src/__tests__/endpoint-extension/string-refs.ts
@@ -1,5 +1,9 @@
 import test from 'ava'
-import { getGraphQLProjectConfig, GraphQLEndpointsExtension } from '../../'
+import {
+  getGraphQLProjectConfig,
+  GraphQLEndpointsExtension,
+  getUsedEnvs,
+} from '../../'
 import { serveSchema } from '../utils'
 
 let endpoints: GraphQLEndpointsExtension
@@ -42,4 +46,19 @@ test('ability to pass external values as env vars to resolveSchemaFromEndpoint',
       .getEndpoint('default', { TEST_ENDPOINT_URL: 'http://127.0.0.1:33333' })
       .resolveSchema()
   })
+})
+
+test('getUsedEnvs', async t => {
+  const configData = {
+    schemaPath: '../schema.json',
+    extensions: {
+      endpoints: {
+        dev: 'http://127.0.0.1:${env:EXTENSION_TEST_PORT}',
+      },
+    },
+  }
+
+  const envs = getUsedEnvs(configData)
+
+  t.is(Object.keys(envs)[0], 'EXTENSION_TEST_PORT')
 })

--- a/src/extensions/endpoints/index.ts
+++ b/src/extensions/endpoints/index.ts
@@ -1,1 +1,3 @@
-export * from './EndpointsExtension';
+export * from './EndpointsExtension'
+
+export * from './resolveRefString'

--- a/src/extensions/endpoints/resolveRefString.ts
+++ b/src/extensions/endpoints/resolveRefString.ts
@@ -11,9 +11,9 @@ export function resolveRefString(str: string, values?: object): string {
   return res
 }
 
-export function resolveEnvsInValues<T extends any> (
+export function resolveEnvsInValues<T extends any>(
   config: T,
-  env: { [name: string]: string | undefined }
+  env: { [name: string]: string | undefined },
 ): T {
   config = Object.assign({}, config)
   for (let key in config) {
@@ -37,8 +37,8 @@ export function getUsedEnvs(config: any): { [name: string]: string } {
         result[parseRef(ref).ref] = resolveRef(ref, {}, false)
       }
     } else if (typeof val === 'object') {
-      for (let key in config) {
-        traverse(config[key])
+      for (let key in val) {
+        traverse(val[key])
       }
     }
   }
@@ -46,24 +46,24 @@ export function getUsedEnvs(config: any): { [name: string]: string } {
   return result
 }
 
-function parseRef(rawRef: string): { type: string, ref: string } {
+function parseRef(rawRef: string): { type: string; ref: string } {
   const [type, ref] = rawRef.split(/\s*:\s*/)
-  return { type, ref}
+  return { type, ref }
 }
 
 function resolveRef(
   rawRef: string,
   values: any = {},
-  throwIfUndef: boolean = true
+  throwIfUndef: boolean = true,
 ): string | null {
-  const {type, ref} = parseRef(rawRef)
+  const { type, ref } = parseRef(rawRef)
 
   if (type === 'env') {
     if (!ref) {
       throw new Error(`Reference value is not present for ${type}: ${rawRef}`)
     }
 
-    const refValue = values.env && values.env[ref] || process.env[ref]
+    const refValue = (values.env && values.env[ref]) || process.env[ref]
     if (!refValue) {
       if (throwIfUndef) {
         throw new Error(`Environment variable ${ref} is not set`)
@@ -74,11 +74,13 @@ function resolveRef(
     return refValue
   } else {
     // support only 'env' for now
-    throw new Error('Undefined reference type ${refType}. Only "env" is supported')
+    throw new Error(
+      'Undefined reference type ${refType}. Only "env" is supported',
+    )
   }
 }
 
-function parse(str: string): { strings: string[], rawRefs: string[] } {
+function parse(str: string): { strings: string[]; rawRefs: string[] } {
   const regex = /\${([^}]*)}/g
   const strings: string[] = []
   const rawRefs: string[] = []


### PR DESCRIPTION
The `traverse` call of `getUsedEnvs` was endless.
Also, I exposed the `getUsedEnvs` method, as it is handy when you want to inject environment variables of a GraphQL Config into a browser environment.