### PR TITLE
Move `rimraf` to `devDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "cpx": "1.5.0",
+    "rimraf": "^2.6.2",
     "tslint": "5.8.0",
     "tslint-config-standard": "7.0.0",
     "typescript": "2.6.2"
@@ -64,7 +65,6 @@
     "graphql-import": "^0.3.0",
     "graphql-request": "^1.4.0",
     "js-yaml": "^3.10.0",
-    "minimatch": "^3.0.4",
-    "rimraf": "^2.6.2"
+    "minimatch": "^3.0.4"
   }
 }


### PR DESCRIPTION
As far as I can tell, it's only used in [the `clean` script](https://github.com/graphcool/graphql-config/blob/600ab26a3855ab9fa7daf3f08d9f3d982095a479/package.json#L14).