### PR TITLE
feat(endpoints): only create GraphQLEndpoint if endpoint is not already GraphQLEndpoint

### DIFF
--- a/src/extensions/endpoints/EndpointsExtension.ts
+++ b/src/extensions/endpoints/EndpointsExtension.ts
@@ -26,7 +26,7 @@ export type GraphQLConfigEnpointsMapData = {
 }
 
 export type GraphQLConfigEnpointsMap = {
-  [env: string]: GraphQLConfigEnpointConfig
+  [env: string]: GraphQLConfigEnpointConfig | GraphQLEndpoint
 }
 
 export type GraphQLConfigEnpointsData = GraphQLConfigEnpointsMapData
@@ -68,7 +68,11 @@ export class GraphQLEndpointsExtension {
   ): GraphQLEndpoint {
     const endpoint = this.getRawEndpoint(endpointName)
     try {
-      return new GraphQLEndpoint(resolveEnvsInValues(endpoint, env))
+      const resolved = resolveEnvsInValues(endpoint, env)
+      if (!(resolved instanceof GraphQLEndpoint)) {
+        return new GraphQLEndpoint(resolved)
+      }
+      return resolved
     } catch (e) {
       e.message = `${this.configPath}: ${e.message}`
       throw e
@@ -99,7 +103,7 @@ export class GraphQLEndpointsExtension {
       )
     }
 
-    if (!endpoint.url) {
+    if (!endpoint.url && !(endpoint instanceof GraphQLEndpoint)) {
       throw new Error(
         `${this
           .configPath}: "url" is required but is not specified for "${endpointName}" endpoint`,

--- a/src/extensions/endpoints/EndpointsExtension.ts
+++ b/src/extensions/endpoints/EndpointsExtension.ts
@@ -69,6 +69,10 @@ export class GraphQLEndpointsExtension {
     const endpoint = this.getRawEndpoint(endpointName)
     try {
       const resolved = resolveEnvsInValues(endpoint, env)
+
+      // graphql-config extensions might have already instantiated a GraphQLEndpoint
+      // or derived class from the GraphQLConfigEndpointConfig data. In that case,
+      // getRawEndpoint will already return a GraphQLEndpoint and it should not be overwritten.
       if (!(resolved instanceof GraphQLEndpoint)) {
         return new GraphQLEndpoint(resolved)
       }

--- a/src/extensions/endpoints/resolveRefString.ts
+++ b/src/extensions/endpoints/resolveRefString.ts
@@ -15,7 +15,6 @@ export function resolveEnvsInValues<T extends any>(
   config: T,
   env: { [name: string]: string | undefined },
 ): T {
-  config = Object.assign({}, config)
   for (let key in config) {
     const value = config[key]
     if (typeof value === 'string') {


### PR DESCRIPTION
The current implementation assumed an endpoint to be GraphQLConfigEndpointConfig. However, if an
extension has already resolved the endpoint configuration to an actual GraphQLEndpoint, this will
overwrite that. The new implementation only creates a new GraphQLEndpoint object, if the endpoint
was not already resolved.

Tested with regular endpoints, the Graphcool extension, the Prisma extension and the OpenApi extension.