### PR TITLE
readme: add vscode-graphql editor extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The easiest way to configure your development environment with your GraphQL sche
 ### Editors
 * [js-graphql-intellij-plugin](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin) - GraphQL language support for IntelliJ IDEA and WebStorm, including Relay.QL tagged templates in JavaScript and TypeScript (_pending_)
 * [atom-language-graphql](https://github.com/rmosolgo/language-graphql) - GraphQL support for Atom text editor (_pending_)
+* [vscode-graphql](https://github.com/stephen/vscode-graphql) - GraphQL support for VSCode text editor
 
 ### Tools
 


### PR DESCRIPTION
vscode-graphql uses the graphql-language-server under the hood and can be configured with a `.graphqlconfig`.
